### PR TITLE
feat(build): support comments in --env-file

### DIFF
--- a/internal/commands/build.go
+++ b/internal/commands/build.go
@@ -389,7 +389,7 @@ func parseEnvFile(filename string) (map[string]string, error) {
 	}
 	for _, line := range strings.Split(string(f), "\n") {
 		line = strings.TrimSpace(line)
-		if line == "" {
+		if line == "" || strings.HasPrefix(line, "#") {
 			continue
 		}
 		out = addEnvVar(out, line)

--- a/internal/commands/build_test.go
+++ b/internal/commands/build_test.go
@@ -404,6 +404,34 @@ func testBuildCommand(t *testing.T, when spec.G, it spec.S) {
 					h.AssertNil(t, command.Execute())
 				})
 			})
+
+			when("an env file with comments is provided", func() {
+				var envPath string
+
+				it.Before(func() {
+					envfile, err := os.CreateTemp("", "envfile")
+					h.AssertNil(t, err)
+					defer envfile.Close()
+
+					envfile.WriteString("# this is a comment\nKEY=VALUE\n# another comment\n")
+					envPath = envfile.Name()
+				})
+
+				it.After(func() {
+					h.AssertNil(t, os.RemoveAll(envPath))
+				})
+
+				it("ignores comment lines and builds with remaining vars", func() {
+					mockClient.EXPECT().
+						Build(gomock.Any(), EqBuildOptionsWithEnv(map[string]string{
+							"KEY": "VALUE",
+						})).
+						Return(nil)
+
+					command.SetArgs([]string{"--builder", "my-builder", "image", "--env-file", envPath})
+					h.AssertNil(t, command.Execute())
+				})
+			})
 		})
 
 		when("a cache-image passed", func() {


### PR DESCRIPTION
Lines starting with '#' in env files passed via --env-file are now ignored, consistent with Docker and dotenv conventions. Also adds a test case covering this behaviour.

## Summary
<!-- Provide a high-level summary of the change. -->

## Output
<!-- If applicable, please provide examples of the output changes. -->

#### Before

#### After

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [ ] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #___
